### PR TITLE
make the data_migration table name work with table_name_prefix and ta…

### DIFF
--- a/lib/generators/templates/create_data_migrations.rb
+++ b/lib/generators/templates/create_data_migrations.rb
@@ -1,11 +1,11 @@
 class CreateDataMigrations < ActiveRecord::Migration
   def self.up
-    create_table :data_migrations do |t|
+    create_table ActiveRecord::DataMigration do |t|
       t.string :version
     end
   end
 
   def self.down
-    drop_table :data_migrations
+    drop_table ActiveRecord::DataMigration
   end
 end

--- a/test/lib/generators/data_migration_install_generator_test.rb
+++ b/test/lib/generators/data_migration_install_generator_test.rb
@@ -18,7 +18,7 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_migration "db/migrate/create_data_migrations.rb"
     assert_migration "db/migrate/create_data_migrations.rb", /class CreateDataMigrations < ActiveRecord::Migration/
-    assert_migration "db/migrate/create_data_migrations.rb", /create_table :data_migrations do |t|/
-    assert_migration "db/migrate/create_data_migrations.rb", /drop_table :data_migrations/
+    assert_migration "db/migrate/create_data_migrations.rb", /create_table ActiveRecord::DataMigration do |t|/
+    assert_migration "db/migrate/create_data_migrations.rb", /drop_table ActiveRecord::DataMigration/
   end
 end


### PR DESCRIPTION
I know the gem from a friend. I read the source code and I see the code below:
```ruby
#lib/active_record/data_migration.rb#L12
def table_name
    "#{table_name_prefix}data_migrations#{table_name_suffix}"
end
```
However, the schema file under the `templates` folder, the table name is fixed. I think it will be better if we can support the `table_name_prefix` and `table_name_suffix` as your wrote in the code.

It's not a bug, just to make it better. :)